### PR TITLE
Correct AWS IoT endpoint type from 'iot:Job"

### DIFF
--- a/website/docs/d/iot_endpoint.html.markdown
+++ b/website/docs/d/iot_endpoint.html.markdown
@@ -36,7 +36,7 @@ resource "kubernetes_pod" "agent" {
 
 ## Argument Reference
 
-* `endpoint_type` - (Optional) Endpoint type. Valid values: `iot:CredentialProvider`, `iot:Data`, `iot:Data-ATS`, `iot:Job`.
+* `endpoint_type` - (Optional) Endpoint type. Valid values: `iot:CredentialProvider`, `iot:Data`, `iot:Data-ATS`, `iot:Jobs`.
 
 ## Attributes Reference
 
@@ -45,4 +45,4 @@ resource "kubernetes_pod" "agent" {
     * `iot:CredentialsProvider`: `IDENTIFIER.credentials.iot.REGION.amazonaws.com`
     * `iot:Data`: `IDENTIFIER.iot.REGION.amazonaws.com`
     * `iot:Data-ATS`: `IDENTIFIER-ats.iot.REGION.amazonaws.com`
-    * `iot:Job`: `IDENTIFIER.jobs.iot.REGION.amazonaws.com`
+    * `iot:Jobs`: `IDENTIFIER.jobs.iot.REGION.amazonaws.com`


### PR DESCRIPTION
Correct AWS IoT endpoint type from 'iot:Job" to "iotJobs"

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
